### PR TITLE
【FIXED】Step4　管理画面関係の実装。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,3 +37,4 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'kaminari'
 gem  'bootstrap'
+gem 'bcrypt', '~> 3.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     autoprefixer-rails (10.4.7.0)
       execjs (~> 2)
+    bcrypt (3.1.18)
     bindex (0.8.1)
     bootsnap (1.12.0)
       msgpack (~> 1.2)
@@ -253,6 +254,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.2)
   bootstrap
   byebug

--- a/app/assets/stylesheets/admin/users.scss
+++ b/app/assets/stylesheets/admin/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the admin::users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/assets/stylesheets/sessions.scss
+++ b/app/assets/stylesheets/sessions.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the sessions controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -3,15 +3,16 @@ class Admin::UsersController < ApplicationController
   before_action :set_user,only:[:show,:edit,:update,:destroy]
 
   def index
-    @users = User.all.order("created_at DESC")
+    @users = User.all.includes(:tasks).order("created_at DESC")
   end
 
   def new
     @user = User.new
   end
-  
+
   def show
     @user = User.find(params[:id])
+    @tasks = @user.tasks
   end
 
   def edit
@@ -45,7 +46,7 @@ class Admin::UsersController < ApplicationController
   def destroy
     @user.destroy
     respond_to do |format|
-      format.html { redirect_to tasks_url, notice: "user は削除されました！" }
+      format.html { redirect_to admin_users_path, notice: "user は削除されました！" }
       format.json { head :no_content }
     end
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,67 @@
+class Admin::UsersController < ApplicationController
+  before_action :if_not_admin
+  before_action :set_user,only:[:show,:edit,:update,:destroy]
+
+  def index
+    @users = User.all.order("created_at DESC")
+  end
+
+  def new
+    @user = User.new
+  end
+  
+  def show
+    @user = User.find(params[:id])
+  end
+
+  def edit
+
+  end
+
+  def create
+    @user = current_user.tasks.build(user_params)
+    
+    respond_to do |format|
+      if @user.save
+        format.html { redirect_to task_url(@task), notice: "Task は作成されました！" }
+        format.json { render :show, status: :created, location: @task }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @user.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+  def update
+    respond_to do |format|
+      if @user.update(user_params)
+        format.html { redirect_to task_url(@task), notice: "Task は更新されました！" }
+        format.json { render :show, status: :ok, location: @task }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @task.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+  def destroy
+    @user.destroy
+    respond_to do |format|
+      format.html { redirect_to tasks_url, notice: "user は削除されました！" }
+      format.json { head :no_content }
+    end
+  end
+
+  
+  private
+
+  def if_not_admin
+    redirect_to root_path unless current_user.admin?
+  end
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def user_params
+    params.require(:user).permit(:name,:email,:password,:password_digest)
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -24,7 +24,7 @@ class Admin::UsersController < ApplicationController
     @user = User.new(user_params)
     respond_to do |format|
       if @user.save
-        format.html { redirect_to user_url(@user), notice: "ユーザーが作成しました" }
+        format.html { redirect_to user_url(@user), notice: "ユーザーを作成しました" }
         format.json { render :show, status: :created, location: @user }
       else
         format.html { render :new, status: :unprocessable_entity }

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -20,29 +20,30 @@ class Admin::UsersController < ApplicationController
   end
 
   def create
-    @user = current_user.tasks.build(user_params)
-    
+    @user = User.new(user_params)
     respond_to do |format|
       if @user.save
-        format.html { redirect_to task_url(@task), notice: "Task は作成されました！" }
-        format.json { render :show, status: :created, location: @task }
+        format.html { redirect_to user_url(@user), notice: "ユーザーが作成しました" }
+        format.json { render :show, status: :created, location: @user }
       else
         format.html { render :new, status: :unprocessable_entity }
         format.json { render json: @user.errors, status: :unprocessable_entity }
       end
     end
   end
+  
   def update
     respond_to do |format|
       if @user.update(user_params)
-        format.html { redirect_to (@task), notice: "Task は更新されました！" }
-        format.json { render :show, status: :ok, location: @task }
+        format.html { redirect_to user_url(@user), notice: "ユーザーの更新に成功しました" }
+        format.json { render :show, status: :ok, location: @user }
       else
         format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @task.errors, status: :unprocessable_entity }
+        format.json { render json: @user.errors, status: :unprocessable_entity }
       end
     end
   end
+
   def destroy
     @user.destroy
     respond_to do |format|
@@ -63,6 +64,6 @@ class Admin::UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:name,:email,:password,:password_digest)
+    params.require(:user).permit(:name,:email,:password,:password_digest,:admin)
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -35,7 +35,7 @@ class Admin::UsersController < ApplicationController
   def update
     respond_to do |format|
       if @user.update(user_params)
-        format.html { redirect_to task_url(@task), notice: "Task は更新されました！" }
+        format.html { redirect_to (@task), notice: "Task は更新されました！" }
         format.json { render :show, status: :ok, location: @task }
       else
         format.html { render :edit, status: :unprocessable_entity }
@@ -55,7 +55,7 @@ class Admin::UsersController < ApplicationController
   private
 
   def if_not_admin
-    redirect_to root_path unless current_user.admin?
+    redirect_to tasks_path flash[:notice] ="管理者以外はアクセスできません"unless current_user.admin?
   end
 
   def set_user

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,4 +1,5 @@
 class Admin::UsersController < ApplicationController
+  
   before_action :if_not_admin
   before_action :set_user,only:[:show,:edit,:update,:destroy]
 
@@ -31,7 +32,7 @@ class Admin::UsersController < ApplicationController
       end
     end
   end
-  
+
   def update
     respond_to do |format|
       if @user.update(user_params)
@@ -51,8 +52,8 @@ class Admin::UsersController < ApplicationController
       format.json { head :no_content }
     end
   end
-
   
+
   private
 
   def if_not_admin
@@ -66,4 +67,6 @@ class Admin::UsersController < ApplicationController
   def user_params
     params.require(:user).permit(:name,:email,:password,:password_digest,:admin)
   end
+
+  
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,11 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
+  include SessionsHelper
+  before_action :login_required
+
+  private
+
+  def login_required
+    redirect_to new_session_path unless current_user
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,23 @@
+class SessionsController < ApplicationController
+  skip_before_action :login_required, only: [:new, :create]
+
+  def new
+  end
+
+  def create
+    user = User.find_by(email: params[:session][:email].downcase)
+    if user && user.authenticate(params[:session][:password])
+      session[:user_id] = user.id
+      redirect_to user_path(user.id)
+    else
+      flash.now[:danger] = 'ログインに失敗しました'
+      render :new
+    end
+  end
+
+  def destroy
+    session.delete(:user_id)
+    flash[:notice] = 'ログアウトしました'
+    redirect_to new_session_path
+  end
+end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,9 +3,9 @@ class TasksController < ApplicationController
 
   # GET /tasks or /tasks.json
   def index
-    @tasks = Task.all.order(created_at: :desc).page params[:page]
-    @tasks=Task.all.order(expired_at: :desc).page params[:page] if params[:sort_expired_at]=="true"   
-    @tasks=Task.all.order(priority: :desc).page params[:page] if params[:sort_priority]=="true" 
+    @tasks = current_user.tasks.order(created_at: :desc).page params[:page]
+    @tasks=current_user.tasks.order(expired_at: :desc).page params[:page] if params[:sort_expired_at]=="true"   
+    @tasks=current_user.tasks.order(priority: :desc).page params[:page] if params[:sort_priority]=="true" 
     if params[:search].present?
       if params[:search][:title].present? && params[:search][:status].present?
         @tasks =@tasks.search_title(params[:search][:title]).search_status(params[:search][:status])
@@ -36,7 +36,6 @@ class TasksController < ApplicationController
   # POST /tasks or /tasks.json
   def create
     @task = current_user.tasks.build(task_params)
-    @task = Task.new(task_params)
     
     respond_to do |format|
       if @task.save

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -35,8 +35,9 @@ class TasksController < ApplicationController
 
   # POST /tasks or /tasks.json
   def create
+    @task = current_user.tasks.build(task_params)
     @task = Task.new(task_params)
-
+    
     respond_to do |format|
       if @task.save
         format.html { redirect_to task_url(@task), notice: "Task は作成されました！" }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,5 @@
+class UsersController < ApplicationController
+  def new
+    @user = User.new
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,8 @@ class UsersController < ApplicationController
   skip_before_action :login_required, only: [:new, :create]
   
   def new
+    redirect_to tasks_path if logged_in? 
+    flash[:notice] ="すでにあなたはログインしていますよ。"
     @user = User.new
   end
 
@@ -16,8 +18,10 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = User.find(params[:id])
-    if @user == current_user
+    if current_user.admin ==true
+      @user = User.find(params[:id])
+    elsif User.find(params[:id])== current_user
+      @user = User.find(params[:id])
     else
       redirect_to tasks_path
     end
@@ -27,6 +31,6 @@ class UsersController < ApplicationController
 
   def user_params
     params.require(:user).permit(:name, :email, :password,
-                                  :password_confirmation)
+                                  :password_confirmation,:admin)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,32 @@
 class UsersController < ApplicationController
+  skip_before_action :login_required, only: [:new, :create]
+  
   def new
     @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      session[:user_id] = @user.id
+      redirect_to user_path(@user.id)
+    else
+      render :new
+    end
+  end
+
+  def show
+    @user = User.find(params[:id])
+    if @user == current_user
+    else
+      redirect_to tasks_path
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :email, :password,
+                                  :password_confirmation)
   end
 end

--- a/app/helpers/admin/users_helper.rb
+++ b/app/helpers/admin/users_helper.rb
@@ -1,0 +1,2 @@
+module Admin::UsersHelper
+end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,0 +1,9 @@
+module SessionsHelper
+  def current_user
+    @current_user ||= User.find_by(id: session[:user_id])
+  end
+
+  def logged_in?
+    current_user.present?
+  end
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -5,6 +5,7 @@ class Task < ApplicationRecord
   validates :status, presence: true
   validates :priority, presence: true
   paginates_per 10
+  belongs_to :user
   enum status:{
     未着手:0, 着手中:1, 完了:2
   } 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -12,6 +12,8 @@ class Task < ApplicationRecord
   enum priority:{
     低:0, 中:1, 高:2
   } 
+  enum admin:{
+    true:0, false:1  } 
   scope :search_title, -> (title) {where("title LIKE ?", "%#{title}%")}
   scope :search_status, -> (status) {where(status: status)}
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,5 +4,5 @@ class User < ApplicationRecord
   before_validation { email.downcase! }
   validates :password, length: { minimum: 6 }
   has_secure_password
-  has_many :tasks
+  has_many :tasks, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,5 @@ class User < ApplicationRecord
   before_validation { email.downcase! }
   validates :password, length: { minimum: 6 }
   has_secure_password
+  has_many :tasks
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,5 +4,19 @@ class User < ApplicationRecord
   before_validation { email.downcase! }
   validates :password, length: { minimum: 6 }
   has_secure_password
-  has_many :tasks, dependent: :destroy
+  has_many :tasks, dependent: :destroy 
+
+  before_update :admin_cannot_update
+before_destroy :admin_cannot_delete
+
+private
+
+def admin_cannot_update
+  throw :abort if User.where(admin: true).count == 1 && self.admin_change == [true, false]
+end
+
+def admin_cannot_delete
+  throw :abort if User.where(admin: true).count == 1 && self.admin == true
+end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,7 @@
+class User < ApplicationRecord
+  validates :name, presence: true, length: { maximum: 30 }
+  validates :email, presence: true, length: { maximum: 50 },format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
+  before_validation { email.downcase! }
+  validates :password, length: { minimum: 6 }
+  has_secure_password
+end

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -12,6 +12,9 @@
 <% end %>
 
 <%= form_with(model: @user, local: true) do |f| %>
+  <%= f.label :管理者 %>
+  <%= f.select :admin, Task.admins.keys, {prompt: "選択してください"} , class: "admin-select"%>
+
   <%= f.label :name %>
   <%= f.text_field :name %>
 
@@ -24,8 +27,6 @@
   <%= f.label :password_confirmation %>
   <%= f.password_field :password_confirmation %>
   
-  <%= f.label :password_confirmation %>
-  <%= f.password_field :password_confirmation %>
 
-  <%= f.submit "新規ユーザー作成" %>
+  <%= f.submit "ユーザー作成" %>
 <% end %>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,0 +1,31 @@
+
+
+<% if @user.errors.any? %>
+  <div id="error_explanation">
+    <h2><%= pluralize(@user.errors.count, "error") %> prohibited this <%= @user.name %> from being saved:</h2>
+    <ul>
+    <% @user.errors.full_messages.each do |message| %>
+      <li><%= message %></li>
+    <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<%= form_with(model: @user, local: true) do |f| %>
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+
+  <%= f.label :email %>
+  <%= f.email_field :email %>
+
+  <%= f.label :password %>
+  <%= f.password_field :password %>
+
+  <%= f.label :password_confirmation %>
+  <%= f.password_field :password_confirmation %>
+  
+  <%= f.label :password_confirmation %>
+  <%= f.password_field :password_confirmation %>
+
+  <%= f.submit "新規ユーザー作成" %>
+<% end %>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -11,7 +11,7 @@
   </div>
 <% end %>
 
-<%= form_with(model: @user, local: true) do |f| %>
+<%= form_with(model:[ :admin, @user ], local: true) do |f| %>
   <%= f.label :管理者 %>
   <%= f.select :admin, Task.admins.keys, {prompt: "選択してください"} , class: "admin-select"%>
 

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -2,5 +2,5 @@
 
 <%= render 'form', user: @user %>
 
-<%= link_to 'Show', @user %> |
-<%= link_to 'Back', users_path %>
+<%= link_to '詳細', admin_user_path %> |
+<%= link_to '戻る', admin_users_path %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>ユーザー編集</h1>
+
+<%= render 'form', user: @user %>
+
+<%= link_to 'Show', @user %> |
+<%= link_to 'Back', users_path %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -12,11 +12,20 @@
 
   <tbody>
     <% @users.each do |user| %>
-      <tr class="task_row">
+      <% counter = 0 %>
+      <tr >
         <td ><%= user.admin %></td>
         <td ><%= user.name %></td>
         <td ><%= user.email %></td>
-        <td ><%= user.tasks.count %></td>
+        <% user.tasks.each do |task| %>
+          <% counter += 1%>
+          <% end %>
+        <td><%= counter%>
+        <%
+=begin%>
+ <td ><%= user.tasks.count %></td> 
+<%
+=end%>
 
         <td><%= link_to '詳細', admin_user_path(user) %></td>
         <td><%= link_to '編集', edit_admin_user_path(user) %></td>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -21,11 +21,6 @@
           <% counter += 1%>
           <% end %>
         <td><%= counter%>
-        <%
-=begin%>
- <td ><%= user.tasks.count %></td> 
-<%
-=end%>
 
         <td><%= link_to '詳細', admin_user_path(user) %></td>
         <td><%= link_to '編集', edit_admin_user_path(user) %></td>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,8 +1,9 @@
 <h1>管理画面<h1>
-<h2>ユーザー一覧<h2>
+<h3>ユーザー 一覧<h2>
 <table class="table">
   <thead>
     <tr>
+      <th scope="col">管理者</th>
       <th scope="col">名前</th>
       <th scope="col">メール</th>
       <th scope="col">タスク数</th>
@@ -12,17 +13,14 @@
   <tbody>
     <% @users.each do |user| %>
       <tr class="task_row">
+        <td ><%= user.admin %></td>
         <td ><%= user.name %></td>
         <td ><%= user.email %></td>
-        <td ><%= user.email %></td>
+        <td ><%= user.tasks.count %></td>
 
-        <td><%= link_to '詳細', user %></td>
-        <%
-=begin%>
- <td><%= link_to '編集', edit_user_path(task) %></td>
-        <td><%= link_to '削除', user, method: :delete, data: { confirm: 'Are you sure?' } %></td>  
-<%
-=end%>
+        <td><%= link_to '詳細', admin_user_path(user) %></td>
+        <td><%= link_to '編集', edit_admin_user_path(user) %></td>
+        <td><%= link_to '削除', admin_user_path(user), method: :delete, data: { confirm: 'Are you sure?' } %></td>   
 
       </tr>
     <% end %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,32 @@
+<h1>管理画面<h1>
+<h2>ユーザー一覧<h2>
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col">名前</th>
+      <th scope="col">メール</th>
+      <th scope="col">タスク数</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @users.each do |user| %>
+      <tr class="task_row">
+        <td ><%= user.name %></td>
+        <td ><%= user.email %></td>
+        <td ><%= user.email %></td>
+
+        <td><%= link_to '詳細', user %></td>
+        <%
+=begin%>
+ <td><%= link_to '編集', edit_user_path(task) %></td>
+        <td><%= link_to '削除', user, method: :delete, data: { confirm: 'Are you sure?' } %></td>  
+<%
+=end%>
+
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+<%= link_to '新規ユーザーを作成', new_admin_user_path %>
+

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'form', user: @user %>
 
-<%= link_to '戻る', users_path %>
+<%= link_to '戻る', admin_users_path %>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -1,0 +1,5 @@
+<h1>新規ユーザー</h1>
+
+<%= render 'form', user: @user %>
+
+<%= link_to '戻る', users_path %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,0 +1,49 @@
+<h1><%= @user.name %>のページ</h1>
+
+<h6>メールアドレス: <%= @user.email %></h6>
+
+<h2>[<%= @user.name %>のタスク一覧]</h2>
+
+<%= form_with(scope: :search,url: tasks_path,local: true, method: :get) do |form| %>
+  <div class="field">
+  タスク名<%= form.text_field :title ,placeholder: "検索..."%> ステータス<%= form.select :status, Task.statuses.keys, {prompt: "---"} , class: "status-select"%><%= form.submit value="検索する"%>
+  </div>
+  
+<% end %>
+<button type="button" class="btn btn-primary"><%= link_to '新規登録', new_task_path %></button>
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col">名前</th>
+      <th scope="col">タスク名</th>
+      <th scope="col">詳しい内容</th>
+      <th scope="col"><%= link_to "終了期限", tasks_path(sort_expired_at: "true") %></th>
+      <th scope="col">登録日時</th>
+      <th scope="col">ステータス</th>
+      <th scope="col"><%= link_to "優先度", tasks_path(sort_priority: "true") %></th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @tasks.each do |task| %>
+      <tr class="task_row">
+        <td ><%= task.user.name %></td>
+        <td ><%= task.title %></td>
+        <td ><%= task.content %></td>
+        <td ><%= task.expired_at %></td>
+        <td ><%= task.created_at %></td>
+        <td ><%= task.status %></td>
+        <td ><%= task.priority %></td>
+        <td><%= link_to '詳細', task %></td>
+        <td><%= link_to '編集', edit_task_path(task) %></td>
+        <td><%= link_to '削除', task, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'タスク一覧', tasks_path %>
+<%= link_to '管理画面', admin_users_path %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,11 +41,11 @@
     <% end %>
 
     <% if logged_in? %>
-      <%= link_to "Profile", user_path(current_user.id) %>
-      <%= link_to "Logout", session_path(current_user.id), method: :delete %>
+      <%= link_to "プロフィール画面", user_path(current_user.id) %>
+      <%= link_to "ログアウト", session_path(current_user.id), method: :delete %>
     <% else %>
-      <%= link_to "Sign up", new_user_path %>
-      <%= link_to "Login", new_session_path %>
+      <%= link_to "サインアップ", new_user_path %>
+      <%= link_to "ログイン画面", new_session_path %>
     <% end %>
     <%= yield %>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,10 +36,22 @@
   </head>
 
   <body>
+    <% flash.each do |key, value| %>
+      <%= content_tag(:div, value, class: "#{key}") %>
+    <% end %>
+
+    <% if logged_in? %>
+      <%= link_to "Profile", user_path(current_user.id) %>
+      <%= link_to "Logout", session_path(current_user.id), method: :delete %>
+    <% else %>
+      <%= link_to "Sign up", new_user_path %>
+      <%= link_to "Login", new_session_path %>
+    <% end %>
     <%= yield %>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+    
 
   </body>
 </html>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,0 +1,11 @@
+<h1>Log in</h1>
+<%= form_with(scope: :session, url: sessions_path, local: true) do |f| %>
+
+  <%= f.label :email %>
+  <%= f.email_field :email %>
+
+  <%= f.label :password %>
+  <%= f.password_field :password %>
+
+  <%= f.submit "Log in" %>
+<% end %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,11 +1,11 @@
-<h1>Log in</h1>
+<h1>ログイン</h1>
 <%= form_with(scope: :session, url: sessions_path, local: true) do |f| %>
 
-  <%= f.label :email %>
+  <%= f.label :メール %>
   <%= f.email_field :email %>
 
-  <%= f.label :password %>
+  <%= f.label :パスワード %>
   <%= f.password_field :password %>
 
-  <%= f.submit "Log in" %>
+  <%= f.submit "ログイン" %>
 <% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,4 +1,4 @@
-<p id="notice"><%= notice %></p>
+
 
 <h1><%= current_user.name %>のタスク一覧</h1>
 <%= form_with(scope: :search,url: tasks_path,local: true, method: :get) do |form| %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -11,6 +11,7 @@
 <table class="table">
   <thead>
     <tr>
+      <th scope="col">名前</th>
       <th scope="col">タスク名</th>
       <th scope="col">詳しい内容</th>
       <th scope="col"><%= link_to "終了期限", tasks_path(sort_expired_at: "true") %></th>
@@ -24,6 +25,7 @@
   <tbody>
     <% @tasks.each do |task| %>
       <tr class="task_row">
+        <td ><%= task.user.name %></td>
         <td ><%= task.title %></td>
         <td ><%= task.content %></td>
         <td ><%= task.expired_at %></td>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,6 +1,6 @@
 <p id="notice"><%= notice %></p>
 
-<h1>タスク一覧</h1>
+<h1><%= current_user.name %>のタスク一覧</h1>
 <%= form_with(scope: :search,url: tasks_path,local: true, method: :get) do |form| %>
   <div class="field">
   タスク名<%= form.text_field :title ,placeholder: "検索..."%> ステータス<%= form.select :status, Task.statuses.keys, {prompt: "---"} , class: "status-select"%><%= form.submit value="検索する"%>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -25,5 +25,5 @@
   <%= @task.priority %>
 </p>
 
-<%= link_to 'Edit', edit_task_path(@task) %> |
-<%= link_to 'Back', tasks_path %>
+<%= link_to '編集', edit_task_path(@task) %> |
+<%= link_to '戻る', tasks_path %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,17 @@
+<h1>Sign up</h1>
+
+<%= form_with(model: @user, local: true) do |f| %>  
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+
+  <%= f.label :email %>
+  <%= f.email_field :email %>
+
+  <%= f.label :password %>
+  <%= f.password_field :password %>
+
+  <%= f.label :password_confirmation %>
+  <%= f.password_field :password_confirmation %>
+
+  <%= f.submit "登録する" %>
+<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,4 +1,4 @@
-<h1>Sign up</h1>
+<h1>サインアップ</h1>
 
 <% if @user.errors.any? %>
   <div id="error_explanation">
@@ -24,5 +24,5 @@
   <%= f.label :password_confirmation %>
   <%= f.password_field :password_confirmation %>
 
-  <%= f.submit "Create my account" %>
+  <%= f.submit "アカウントを作る" %>
 <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,6 +1,17 @@
 <h1>Sign up</h1>
 
-<%= form_with(model: @user, local: true) do |f| %>  
+<% if @user.errors.any? %>
+  <div id="error_explanation">
+    <h2><%= pluralize(@user.errors.count, "error") %> prohibited this <%= @user.name %> from being saved:</h2>
+    <ul>
+    <% @user.errors.full_messages.each do |message| %>
+      <li><%= message %></li>
+    <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<%= form_with(model: @user, local: true) do |f| %>
   <%= f.label :name %>
   <%= f.text_field :name %>
 
@@ -13,5 +24,5 @@
   <%= f.label :password_confirmation %>
   <%= f.password_field :password_confirmation %>
 
-  <%= f.submit "登録する" %>
+  <%= f.submit "Create my account" %>
 <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,5 @@
+<h1><%= @user.name %>のページ</h1>
+
+<p>メールアドレス: <%= @user.email %></p>
+
+<%= link_to 'タスク一覧', tasks_path %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,9 +2,9 @@
 
 <p>メールアドレス: <%= @user.email %></p>
 
-<%= link_to 'タスク一覧', tasks_path %>
+<%= link_to 'タスク一覧へ', tasks_path %>
 
 <% if current_user.admin == true %>
-<%= link_to '管理画面', admin_users_path %>
+<%= link_to '管理画面へ', admin_users_path %>
 <% else %>
 <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,4 +3,8 @@
 <p>メールアドレス: <%= @user.email %></p>
 
 <%= link_to 'タスク一覧', tasks_path %>
+
+<% if current_user.admin == true %>
 <%= link_to '管理画面', admin_users_path %>
+<% else %>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,3 +3,4 @@
 <p>メールアドレス: <%= @user.email %></p>
 
 <%= link_to 'タスク一覧', tasks_path %>
+<%= link_to '管理画面', admin_users_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
+  get 'sessions/new'
   root 'tasks#index'
+  resources :sessions, only: [:new, :create, :destroy]
   resources :tasks
-  resources :users, only: [:new,:create]
+  resources :users, only: [:new,:create, :show]
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,9 @@ Rails.application.routes.draw do
   root 'tasks#index'
   resources :sessions, only: [:new, :create, :destroy]
   resources :tasks
-  resources :users, only: [:new,:create, :show]
+  resources :users, only: [:index,:new,:create, :show]
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  namespace :admin do
+    resources :users, only: [:index, :new, :create, :show,  :edit, :destroy]
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,6 @@ Rails.application.routes.draw do
   resources :users, only: [:index,:new,:create, :show]
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   namespace :admin do
-    resources :users, only: [:index, :new, :create, :show,  :edit, :destroy]
+    resources :users, only: [:index, :new, :create, :show,  :edit, :destroy,:update]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   root 'tasks#index'
   resources :tasks
+  resources :users, only: [:new,:create]
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20220719090430_create_users.rb
+++ b/db/migrate/20220719090430_create_users.rb
@@ -1,0 +1,11 @@
+class CreateUsers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :users do |t|
+      t.string :name
+      t.string :email
+      t.string :password_digest
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220719091142_add_index_to_users_email.rb
+++ b/db/migrate/20220719091142_add_index_to_users_email.rb
@@ -1,0 +1,5 @@
+class AddIndexToUsersEmail < ActiveRecord::Migration[6.0]
+  def change
+    add_index :users, :email, unique: true
+  end
+end

--- a/db/migrate/20220719133008_add_user_ref_to_tasks.rb
+++ b/db/migrate/20220719133008_add_user_ref_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddUserRefToTasks < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :tasks, :user, foreign_key: true
+  end
+end

--- a/db/migrate/20220721024147_add_admin_to_user.rb
+++ b/db/migrate/20220721024147_add_admin_to_user.rb
@@ -1,0 +1,5 @@
+class AddAdminToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_19_133008) do
+ActiveRecord::Schema.define(version: 2022_07_21_024147) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 2022_07_19_133008) do
     t.string "password_digest"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "admin", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_19_091142) do
+ActiveRecord::Schema.define(version: 2022_07_19_133008) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,7 +23,9 @@ ActiveRecord::Schema.define(version: 2022_07_19_091142) do
     t.datetime "expired_at"
     t.integer "status"
     t.integer "priority"
+    t.bigint "user_id"
     t.index ["title"], name: "index_tasks_on_title"
+    t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -35,4 +37,5 @@ ActiveRecord::Schema.define(version: 2022_07_19_091142) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "tasks", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_14_062954) do
+ActiveRecord::Schema.define(version: 2022_07_19_091142) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,15 @@ ActiveRecord::Schema.define(version: 2022_07_14_062954) do
     t.integer "status"
     t.integer "priority"
     t.index ["title"], name: "index_tasks_on_title"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "name"
+    t.string "email"
+    t.string "password_digest"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,11 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+User.create(name: "kenji",email:"kenji@gmail.com",password:"kenjikenji")
+User.create(name: "taro")
+# 配列でまとめて作成
+# users = User.create([{name: "hanako"}, {name: "misa"}])
+# ループでまとめて作成
+# 3.times do |i|
+# Article.create(user_id: User.find(i+1).id, title: "Star Wars #{i+1}")
+# end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,7 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 User.create(name: "kenji",email:"kenji@gmail.com",password:"kenjikenji")
-User.create(name: "taro")
+User.create(name: "taro",email:"taro@gmail.com",password:"tarotaro")
 # 配列でまとめて作成
 # users = User.create([{name: "hanako"}, {name: "misa"}])
 # ループでまとめて作成

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,6 +7,11 @@
 #   Character.create(name: 'Luke', movie: movies.first)
 User.create(name: "kenji",email:"kenji@gmail.com",password:"kenjikenji")
 User.create(name: "taro",email:"taro@gmail.com",password:"tarotaro")
+User.create!(username:  "管理者",
+  email: "admin@example.jp",
+  password:  "11111111",
+  password_confirmation: "11111111",
+  admin: true)
 # 配列でまとめて作成
 # users = User.create([{name: "hanako"}, {name: "misa"}])
 # ループでまとめて作成

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,21 +1,22 @@
-# 「FactoryBotを使用します」という記述
 FactoryBot.define do
   factory :task, class: Task do
+    user
     title { 'test_title' }
     content { 'test_content' }
     expired_at{Date.today}
     created_at{Date.today}
     status{1}
-    priority{0}
+    priority{1}
   end
 
   factory :second_task, class: Task do
+    user
     title { 'test_title2' }
     content { 'test_content2' }
     expired_at{Date.today+1}
     created_at{Date.today+1}
     status{1}
-    priority{1}
+    priority{0}
   end
   factory :third_task, class: Task do
     title { 'test_title3' }
@@ -26,8 +27,3 @@ FactoryBot.define do
     priority{2}
   end
 end
-
-# fill_in "task[title]", with:"test_title"
-#         fill_in "task[content]", with:"test_content"
-#         fill_in "task[expired_at]", with:"002022-07-15"
-#         fill_in "task[status]", with:"test_content"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :user do
+    
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,17 @@
 FactoryBot.define do
   factory :user do
-    
+    name { 'test_name' }
+    email { 'test_email@gmail.com' }
+    password{'test_password'}
+    created_at{Date.today}
+    admin{false}
+  end
+
+  factory :admin_user, class: User do
+    name { 'admin_name' }
+    email { 'admin_email@gmail.com' }
+    password{'admin_password'}
+    created_at{Date.today}
+    admin{true}
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,6 +5,16 @@ FactoryBot.define do
     password{'test_password'}
     created_at{Date.today}
     admin{false}
+    id{101}
+  end
+
+  factory :second_user , class: User do
+    name { 'test_name2' }
+    email { 'test_email2@gmail.com' }
+    password{'test_password2'}
+    created_at{Date.today}
+    admin{false}
+    id{102}
   end
 
   factory :admin_user, class: User do
@@ -13,5 +23,6 @@ FactoryBot.define do
     password{'admin_password'}
     created_at{Date.today}
     admin{true}
+    id{110}
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/system/admin_spec.rb
+++ b/spec/system/admin_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+RSpec.describe 'タスク管理機能', type: :system do
+  let!(:user) { FactoryBot.create(:user) }
+  let!(:admin_user) { FactoryBot.create(:admin_user) }
+
+
+  describe '管理画面のテスト' do
+    context '管理画面へを押すと' do
+      it '管理画面にアクセスできる' do
+        visit sessions_new_path
+        fill_in "session[email]", with:"admin_email@gmail.com"
+        fill_in "session[password]", with:"admin_password"
+        click_on "ログイン"
+        click_on "管理画面へ"
+        expect(page).to have_content 'ユーザー 一覧'
+      end
+    end
+    context '一般ユーザが管理画面にアクセスしようとする場合' do
+      it '管理者以外はアクセスできません' do
+        visit sessions_new_path
+        fill_in "session[email]", with:"test_email@gmail.com"
+        fill_in "session[password]", with:"test_password"
+        click_on "ログイン"
+        visit admin_users_path
+        expect(page).to have_content '管理者以外はアクセスできません'
+      end
+    end
+
+    before do
+        visit sessions_new_path
+        fill_in "session[email]", with:"admin_email@gmail.com"
+        fill_in "session[password]", with:"admin_password"
+        click_on "ログイン"
+    end
+
+    context '管理ユーザがユーザの新規登録する場合' do
+      it 'ユーザの新規登録ができる' do
+        click_on "管理画面へ"
+        click_on "新規ユーザーを作成"
+        select "false", from:"user[admin]"
+        fill_in "user[name]", with:"test3_name"
+        fill_in "user[email]", with:"test3_email@gmail.com"
+        fill_in "user[password]", with:"test3_password"
+        fill_in "user[password_confirmation]", with:"test3_password"
+        click_on "ユーザー作成"
+        expect(page).to have_content 'ユーザーを作成しました'
+      end
+    end
+    context '管理ユーザがユーザの詳細画面にアクセスした場合' do
+      it 'ユーザの詳細画面にアクセスができる' do
+        click_on "管理画面へ"
+        visit admin_user_path (User.find(101))
+        expect(page).to have_content '[test_nameのタスク一覧]'
+      end
+    end
+    context '管理ユーザがユーザ編集画面にアクセスした場合' do
+      it 'ユーザを編集できる' do
+        click_on "管理画面へ"
+        visit edit_admin_user_path (User.find(101))
+        select "false", from:"user[admin]"
+        fill_in "user[name]", with:"test4_name"
+        fill_in "user[email]", with:"test4_email@gmail.com"
+        fill_in "user[password]", with:"test4_password"
+        fill_in "user[password_confirmation]", with:"test4_password"
+        click_on "ユーザー作成"
+        expect(page).to have_content 'test4_nameのページ'
+      end
+    end
+    context '管理ユーザがユーザを削除した場合' do
+      it 'ユーザが削除できる' do
+        click_on "管理画面へ"
+        click_on "削除", match: :first
+        page.driver.browser.switch_to.alert.accept
+        expect(page).to have_content 'user は削除されました！'
+      end
+    end
+  end
+end

--- a/spec/system/session_spec.rb
+++ b/spec/system/session_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+RSpec.describe 'タスク管理機能', type: :system do
+  let!(:user) { FactoryBot.create(:user) }
+
+  before do
+    visit sessions_new_path
+    fill_in "session[email]", with:"test_email@gmail.com"
+    fill_in "session[password]", with:"test_password"
+    click_on "ログイン"
+  end
+
+  describe 'セッション機能のテスト' do
+    context 'ログインした場合' do
+      it 'マイページに飛ぶ' do
+        expect(page).to have_content 'test_nameのページ'
+      end
+    end
+    context '他人の詳細画面に飛ぶ場合' do
+      it 'タスク一覧画面に遷移する' do
+        click_on "ログアウト"
+        FactoryBot.create(:second_user ) 
+        fill_in "session[email]", with:"test_email2@gmail.com"
+        fill_in "session[password]", with:"test_password2"
+        click_on "ログイン"
+        visit  user_path (User.find(101))
+        expect(page).to have_content 'test_name2のタスク一覧'
+      end
+    end
+    context 'ログアウト飛ぶ場合' do
+      it 'ログアウトしましたが表示する' do
+        click_on "ログアウト"
+        expect(page).to have_content 'ログアウトしました'
+      end
+    end
+  end
+end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe 'タスク管理機能', type: :system do
       end
     end
 
-    # テスト内容を追加で記載する
     context 'タスクが作成日時の降順に並んでいる場合' do
       it '新しいタスクが一番上に表示される' do
         FactoryBot.create(:task, title:"test_title", created_at:Date.today, user: user)

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -81,7 +81,6 @@ RSpec.describe 'タスク管理機能', type: :system do
         FactoryBot.create(:second_task, title: "sample", status: "未着手")
         visit tasks_path
         fill_in "search[title]", with:"t"
-        task_list = all('.task_row')
         click_on "検索する" 
         task_list = all('.task_row')
         expect(task_list[0]).to have_content 'test_title'

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -1,10 +1,16 @@
 require 'rails_helper'
 RSpec.describe 'タスク管理機能', type: :system do
-  let!(:task) { FactoryBot.create(:task, title: 'test_title') }
+  let!(:user) { FactoryBot.create(:user) }
+  let!(:admin_user) { FactoryBot.create(:admin_user) }
+  
   before do
-    # 「一覧画面に遷移した場合」や「タスクが作成日時の降順に並んでいる場合」など、contextが実行されるタイミングで、before内のコードが実行される
-    visit tasks_path
+    visit sessions_new_path
+    fill_in "session[email]", with:"test_email@gmail.com"
+    fill_in "session[password]", with:"test_password"
+    click_on "ログイン"
+    click_on "タスク一覧へ"
   end
+  
   describe '新規作成機能' do
     context 'タスクを新規作成した場合' do
       it '作成したタスクが表示される' do        
@@ -13,16 +19,19 @@ RSpec.describe 'タスク管理機能', type: :system do
         fill_in "task[content]", with:"test_content"
         select "未着手", from:"task[status]"
         select "低", from:"task[priority]"
-        click_on "登録する"        
+        click_on "登録する"   
+        click_on "戻る"
         expect(page).to have_content 'test_title'
       end
     end 
     context '終了期限でソートした場合' do
       it '終了期限で降順に一覧が表示される' do
-        FactoryBot.create(:task ) 
-        FactoryBot.create(:second_task )
+        FactoryBot.create(:task, user: user ) 
+        
+        FactoryBot.create(:second_task, user: user)
         visit tasks_path
         click_on '終了期限'
+        sleep(0.5)
         task_list = all('.task_row')
         expect(task_list[0]).to have_content 'test_title2'
         expect(task_list[1]).to have_content 'test_title'
@@ -30,13 +39,14 @@ RSpec.describe 'タスク管理機能', type: :system do
     end
     context '優先順位でソートした場合' do
       it '優先順位で降順に一覧が表示される' do
-        FactoryBot.create(:task ) 
-        FactoryBot.create(:second_task )
+        FactoryBot.create(:task, user: user  ) 
+        FactoryBot.create(:second_task, user: user  )
         visit tasks_path
         click_on '優先度'
+        sleep(0.5)
         task_list = all('.task_row')
-        expect(task_list[0]).to have_content 'test_title2'
-        expect(task_list[1]).to have_content 'test_title'
+        expect(task_list[0]).to have_content 'test_title'
+        expect(task_list[1]).to have_content 'test_title2'
       end
     end
   end
@@ -44,7 +54,7 @@ RSpec.describe 'タスク管理機能', type: :system do
   describe '一覧表示機能' do
     context '一覧画面に遷移した場合' do
       it '作成済みのタスク一覧が表示される' do
-        task = FactoryBot.create(:task, title:"test_title")
+        task = FactoryBot.create(:task, title:"test_title", user: user)
         visit tasks_path
         expect(page).to have_content 'test_title'
       end
@@ -53,8 +63,8 @@ RSpec.describe 'タスク管理機能', type: :system do
     # テスト内容を追加で記載する
     context 'タスクが作成日時の降順に並んでいる場合' do
       it '新しいタスクが一番上に表示される' do
-        FactoryBot.create(:task, title:"test_title", created_at:Date.today)
-        FactoryBot.create(:task, title:"test_title2",content:"test_content2", created_at:Date.today+1)
+        FactoryBot.create(:task, title:"test_title", created_at:Date.today, user: user)
+        FactoryBot.create(:task, title:"test_title2",content:"test_content2", created_at:Date.today+1, user: user)
         visit tasks_path
         task_list = all('.task_row')
         expect(task_list[0]).to have_content 'test_title2'
@@ -67,7 +77,7 @@ RSpec.describe 'タスク管理機能', type: :system do
   describe '詳細表示機能' do
     context '任意のタスク詳細画面に遷移した場合' do
       it '該当タスクの内容が表示される' do
-        task = FactoryBot.create(:task, title:"test_title")
+        task = FactoryBot.create(:task, title:"test_title", user: user)
         visit task_path(task.id)
         expect(page).to have_content 'test_title'
       end
@@ -77,22 +87,21 @@ RSpec.describe 'タスク管理機能', type: :system do
   describe '検索機能' do
     context 'タイトルであいまい検索をした場合' do
       it "検索キーワードを含むタスクで絞り込まれる" do
-        FactoryBot.create(:task, title: "test", status: "着手中")
-        FactoryBot.create(:second_task, title: "sample", status: "未着手")
+        FactoryBot.create(:task, title: "test", status: "着手中", user: user)
+        FactoryBot.create(:second_task, title: "sample", status: "未着手", user: user)
         visit tasks_path
         fill_in "search[title]", with:"t"
         click_on "検索する" 
         task_list = all('.task_row')
-        expect(task_list[0]).to have_content 'test_title'
-        expect(task_list[1]).to have_content 'test'
-        expect(task_list[2]).to have_content ''
+        expect(task_list[0]).to have_content 'test'
+        expect(task_list[1]).to have_content ''
       end
     end
 
     context 'ステータス検索をした場合' do
       it "ステータスに完全一致するタスクが絞り込まれる" do
-        FactoryBot.create(:task, title: "test", status: "着手中")
-        FactoryBot.create(:second_task, title: "sample", status: "未着手")
+        FactoryBot.create(:task, title: "test", status: "着手中", user: user)
+        FactoryBot.create(:second_task, title: "sample", status: "未着手", user: user)
         visit tasks_path
         select "未着手", from:"search[status]"
         click_on "検索する" 
@@ -104,9 +113,9 @@ RSpec.describe 'タスク管理機能', type: :system do
 
     context 'タイトルのあいまい検索とステータス検索をした場合' do
       it "検索キーワードをタイトルに含み、かつステータスに完全一致するタスク絞り込まれる" do
-        FactoryBot.create(:task, title: "test", status: "着手中")
-        FactoryBot.create(:second_task, title: "sample", status: "未着手")
-        FactoryBot.create(:third_task, title: "test", status: "未着手")
+        FactoryBot.create(:task, title: "test", status: "着手中", user: user)
+        FactoryBot.create(:second_task, title: "sample", status: "未着手", user: user)
+        FactoryBot.create(:third_task, title: "test", status: "未着手", user: user)
         visit tasks_path
         fill_in "search[title]", with:"t"
         select "未着手", from:"search[status]"
@@ -117,6 +126,5 @@ RSpec.describe 'タスク管理機能', type: :system do
         expect(task_list[1]).to have_content ''
       end
     end
-
   end
 end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -26,8 +26,7 @@ RSpec.describe 'タスク管理機能', type: :system do
     end 
     context '終了期限でソートした場合' do
       it '終了期限で降順に一覧が表示される' do
-        FactoryBot.create(:task, user: user ) 
-        
+        FactoryBot.create(:task, user: user )         
         FactoryBot.create(:second_task, user: user)
         visit tasks_path
         click_on '終了期限'

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe 'タスク管理機能', type: :system do
   #   【共通の前準備をする】
   # end
 
-  describe '【ユーザ登録のテスト】' do
-    context '【ユーザの新規登録した場合】' do
-      it '【作成したユーザーログインできる】' do
+  describe 'ユーザ登録のテスト' do
+    context 'ユーザの新規登録した場合' do
+      it '作成したユーザーログインできる' do
         visit new_user_path
         fill_in "user[name]", with:"test_name"
         fill_in "user[email]", with:"test_email@gmail.com"
@@ -14,6 +14,12 @@ RSpec.describe 'タスク管理機能', type: :system do
         fill_in "user[password_confirmation]", with:"test_password"
         click_on "アカウントを作る"
         expect(page).to have_content 'test_nameのページ'
+      end
+    end  
+    context 'ログインせずタスク一覧画面に飛ぼうとした場合' do
+      it 'ログイン画面に遷移すること' do
+        visit tasks_path
+        expect(page).to have_content 'ログイン'
       end
     end
   end

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -1,8 +1,5 @@
 require 'rails_helper'
 RSpec.describe 'タスク管理機能', type: :system do
-  # before do
-  #   【共通の前準備をする】
-  # end
 
   describe 'ユーザ登録のテスト' do
     context 'ユーザの新規登録した場合' do

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+RSpec.describe 'タスク管理機能', type: :system do
+  # before do
+  #   【共通の前準備をする】
+  # end
+
+  describe '【ユーザ登録のテスト】' do
+    context '【ユーザの新規登録した場合】' do
+      it '【作成したユーザーログインできる】' do
+        visit new_user_path
+        fill_in "user[name]", with:"test_name"
+        fill_in "user[email]", with:"test_email@gmail.com"
+        fill_in "user[password]", with:"test_password"
+        fill_in "user[password_confirmation]", with:"test_password"
+        click_on "アカウントを作る"
+        expect(page).to have_content 'test_nameのページ'
+      end
+    end
+  end
+end


### PR DESCRIPTION
ユーザモデルを作成する
最初のユーザをseedで作成する
ユーザとタスクを紐づける
タスク一覧画面とマイページに表示されているすべてのタスクに、作成したユーザ名を表示させること
ユーザのemailにユニーク制約をつける
関連（アソシエーションで使用するid）に対してインデックスをつける
bcrypt-ruby以外は、Gemを使わずに実装する
ログイン機能を実装する
ログインをせずにタスク一覧のページに飛ぼうとしたときは、ログインページに遷移させる
自分が作成したタスクだけを表示させる
ログアウト機能を実装する
ユーザの新規登録画面、ログイン画面、詳細・マイページ（show）画面を作成する
ユーザを新規登録（create）をしたとき、同時にログインもさせる
ログインしているときは、ユーザの新規登録画面（new画面）に行かせないようにコントローラで制御する
自分（current_user）以外のユーザのマイページ（userのshow画面）にアクセスしたらタスク一覧に遷移させる
管理画面を追加する
管理画面にはかならず /admin というURLを先頭につける
管理画面でユーザ一覧表示・作成・更新・削除ができる（管理画面のビューは、パーシャル化しなくても構わない）
ユーザを削除したら、そのユーザに紐づいているタスクを全て削除する
ユーザの一覧画面で、そのユーザに紐づいているタスクの数を表示する
N+1問題を回避するための仕組みを取り入れること
ユーザが作成したタスクの一覧を、そのユーザのマイページ（userのshow画面）で見られる
ユーザを管理ユーザと一般ユーザで区別する
管理ユーザだけがユーザ管理画面にアクセスできる
一般ユーザが管理画面にアクセスしたとき、tasks/indexに飛ばして「管理者以外はアクセスできない」旨のflashメッセージを出力する
ユーザ管理画面でロール（管理者権限）の付与と削除ができる
管理ユーザが一人もいなくなってしまわないように、モデルのコールバックを利用して更新・削除の制御をする
テスト項目を満たすようSystem Specを書く
ユーザ登録のテスト
ユーザの新規登録ができること
ユーザがログインせずタスク一覧画面に飛ぼうとしたとき、ログイン画面に遷移すること
セッション機能のテスト
ログインができること
自分の詳細画面(マイページ)に飛べること
一般ユーザが他人の詳細画面に飛ぶとタスク一覧画面に遷移すること
ログアウトができること
管理画面のテスト
管理ユーザは管理画面にアクセスできること
一般ユーザは管理画面にアクセスできないこと
管理ユーザはユーザの新規登録ができること
管理ユーザはユーザの詳細画面にアクセスできること
管理ユーザはユーザの編集画面からユーザを編集できること
管理ユーザはユーザの削除をできること
ブランチのstep4をherokuにデプロイし、herokuのURLを提出すること
Herokuにデプロイした際に、すでに登録されているタスクとユーザが紐づいているようにすること